### PR TITLE
proposal to extend `smart-compile` to flexibly identify build systems in monorepos

### DIFF
--- a/smart-compile.el
+++ b/smart-compile.el
@@ -30,6 +30,8 @@
 ;; This package provides `smart-compile' function.
 ;; You can associate a particular file with a particular compile function,
 ;; by editing `smart-compile-alist'.
+;; If you are using a build system such as make or cargo, you can associate its build file with a
+;; compile function as well, by editing `smart-compile-build-system-alist'.
 ;;
 ;; To use this package, add these lines to your .emacs file:
 ;;     (require 'smart-compile)
@@ -181,6 +183,12 @@ If the matching alist entry is a (REGEXP . STRING), then the same %-sequence rep
       (setq cur-dir (expand-file-name ".." cur-dir)))
     found-entry))
 
+(defun smart-compile--explicit-same-dir-filename (path)
+  "Return a file path that always has a leading directory component."
+  (if (file-name-directory path)
+      path
+    (format "./%s" path)))
+
 ;;;###autoload
 (defun smart-compile (&optional arg)
   "An interface to `compile'.
@@ -216,7 +224,8 @@ which is defined in `smart-compile-alist'."
                         (smart-compile-string command-string-entry)
                       (eval command-string-entry))))
               (if (y-or-n-p (format "%s is found. Try %S in its directory?"
-                                    matched-file command-string))
+                                    (smart-compile--explicit-same-dir-filename matched-file)
+                                    command-string))
                   ;; Same directory returns nil for `file-name-directory'.
                   (let ((wrapping-dir (file-name-directory matched-file)))
                     (set (make-local-variable 'compile-command)

--- a/smart-compile.el
+++ b/smart-compile.el
@@ -114,14 +114,14 @@ evaluate FUNCTION instead of running a compilation command.
 (make-variable-buffer-local 'smart-compile-build-root-directory)
 
 (defconst smart-compile-replace-alist '(
-  ("%F" . buffer-file-name)
+  ("%F" . (buffer-file-name))
   ("%f" . (file-relative-name
-           buffer-file-name
+           (buffer-file-name)
            smart-compile-build-root-directory))
-  ("%n" . (file-relative-name
-           (file-name-sans-extension buffer-file-name)
+  ("%n" . (file-relative-name/
+           (file-name-sans-extension (buffer-fi [] le-name))
            smart-compile-build-root-directory))
-  ("%e" . (or (file-name-extension buffer-file-name) ""))
+  ("%e" . (or (file-name-extension (buffer-file-name)) ""))
   ("%o" . smart-compile-option-string)
 ;;   ("%U" . (user-login-name))
   )

--- a/smart-compile.el
+++ b/smart-compile.el
@@ -223,7 +223,7 @@ which is defined in `smart-compile-alist'."
                     (if (stringp command-string-entry)
                         (smart-compile-string command-string-entry)
                       (eval command-string-entry))))
-              (if (y-or-n-p (format "%s is found. Try %S in its directory?"
+              (if (y-or-n-p (format "%s is found. Try '%s' in its directory?"
                                     (smart-compile--explicit-same-dir-filename matched-file)
                                     command-string))
                   ;; Same directory returns nil for `file-name-directory'.

--- a/smart-compile.el
+++ b/smart-compile.el
@@ -125,7 +125,8 @@ evaluate FUNCTION instead of running a compilation command.
   :group 'smart-compile)
 
 (defcustom smart-compile-build-system-alist
-  '(("[mM]akefile" . smart-compile-make-program))
+  '(("\\`[mM]akefile\\'" . smart-compile-make-program)
+    ("\\`Cargo.toml\\'" . "cargo build "))
   "Alist of \"build file\" patterns vs corresponding format control strings.
 
 Similar to `smart-compile-alist', each element may look like (REGEXP . STRING) or

--- a/smart-compile.el
+++ b/smart-compile.el
@@ -219,7 +219,7 @@ which is defined in `smart-compile-alist'."
 ;;     (message (number-to-string arg))
 
     ;; Set the "root" directory next to the file, for most cases.
-    (setq-local smart-compile-build-root-directory default-directory)
+    (setq smart-compile-build-root-directory default-directory)
     (cond
 
      ;; local command

--- a/smart-compile.el
+++ b/smart-compile.el
@@ -74,8 +74,6 @@
   ("\\.raku\\'"       . "perl6 %f")
   ("\\.rb\\'"         . "ruby %f")
   ("\\.rs\\'"         . "rustc %f -o %n")
-  ("Rakefile\\'"      . "rake")
-  ("Gemfile\\'"       . "bundle install")
   ("\\.tex\\'"        . (tex-file))
   ("\\.texi\\'"       . "makeinfo %f")
 ;;  ("\\.php\\'"        . "php -l %f") ; syntax check
@@ -136,7 +134,9 @@ evaluate FUNCTION instead of running a compilation command.
 (defcustom smart-compile-build-system-alist
   '(("\\`[mM]akefile\\'" . smart-compile-make-program)
     ("\\`Cargo.toml\\'" . "cargo build ")
-    ("\\`pants\\'" . "./pants %f"))
+    ("\\`pants\\'" . "./pants %f")
+    ("Gemfile\\'"       . "bundle install")
+    ("Rakefile\\'"      . "rake"))
   "Alist of \"build system file\" patterns vs corresponding format control strings.
 
 Similar to `smart-compile-alist', each element may look like (REGEXP . STRING) or

--- a/smart-compile.el
+++ b/smart-compile.el
@@ -188,7 +188,7 @@ which is defined in `smart-compile-alist'."
   (interactive "p")
   (let ((name (buffer-file-name))
         (not-yet t))
-    
+
     (if (not name)(error "cannot get filename."))
 ;;     (message (number-to-string arg))
 
@@ -229,7 +229,7 @@ which is defined in `smart-compile-alist'."
      ) ;; end of (cond ...)
 
     ;; compile
-    (let( (alist smart-compile-alist) 
+    (let( (alist smart-compile-alist)
           (case-fold-search nil)
           (function nil) )
       (while (and alist not-yet)
@@ -271,14 +271,14 @@ which is defined in `smart-compile-alist'."
               (set (make-local-variable 'compile-command) name)
             ))
       )
-    
+
     ;; compile
     (if not-yet (call-interactively 'compile) )
 
     ))
 
 (defun smart-compile-string (format-string)
-  "Document forthcoming..."
+  "Replace all the special format specifiers from `smart-compile-replace-alist' in FORMAT-STRING."
   (if (and (boundp 'buffer-file-name)
            (stringp buffer-file-name))
       (let ((rlist smart-compile-replace-alist)


### PR DESCRIPTION
Hello! I have been using your package for years! It's great!

Upon realizing it was on MELPA (I had just copied the file into my own emacs init before), I tried to see what I had added to it. I think I have found a really cool way to extend the package, but not by too much.

### Problem
This tries to solve two problems:
1. I want to run `smart-compile` with `make`, but if my `Makefile` isn't right next to the file (e.g. `../Makefile`, in a parent directory), it fails.
2. I want to run `smart-compile` with more than just `make`.

These two would happen, for example, in a "monorepo", where I have used it for years at Twitter to smartly compile with [**pants**](https://github.com/pantsbuild/pants)

### Solution
1. Now, if there is a `Makefile` in any parent directory, `smart-compile` will ask, for example:
> `../Makefile is found. Try 'make ' in its directory?`
2. There's a new defcustom `smart-compile-build-system-alist`, which tries to match the behavior of `smart-compile-alist`, but instead to run on a "build system file":
  - Alist of `(REGEX . STRING)` or `(REGEX . SEXP)`.
  - The "build system file" is any non-directory file matching `REGEX` in any parent directory,
### Result
- `smart-compile` will **`cd` into the directory with the generalized "build system file".**
  - If the matching entry in `smart-compile-build-system-alist` is a `(REGEX . STRING)`, it performs the same format string substitution as specified in `smart-compile-replace-alist`, where the file is set to the "build file".
  - In addition to `make`, it also has added support for `cargo` and `./pants`.

**Note:** we may want to add another `defcustom` to limit how many parents it will check? I just ended up using `4` for all of my choices in the code I just deleted: https://github.com/cosmicexplorer/.emacs.d/commit/36079382ede69719058ee048ef57ee8623c3fc38#diff-d7cee76abae5125a7d2d1a746d9e194c93f4ddf48685eac5774ff84a8ff181a5L277-L285. 
 - That code was obviously *too* complex, so I wanted a chance to clean this up instead, and I found it could be a good general contribution. I hope this is flexible enough to **avoid** tons of further changes, and to help people like me **drop** any hacked-on versions.
 - If the above link in the diff doesn't work, try this direct link to where I set this: https://github.com/cosmicexplorer/.emacs.d/blob/bde24aaa9e8fa0dec2f2628712d3966b9610ee0d/lisp/smart-compile.el#L277-L285 

 **I believe I have only used concepts which exist in emacs 22 to implement this.** Please let me know if I have missed anything.

Thank you for your work!